### PR TITLE
Fix shell label clipped at top of hero code box

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,8 @@
       </aside>
     </div>
 
-    <pre class="hero-code" aria-hidden="true">&gt; whoami
+    <div class="hero-code-wrap" aria-hidden="true">
+      <pre class="hero-code">&gt; whoami
 nsorros &mdash; Head of Data / AI &middot; CTO
 
 &gt; stack
@@ -102,6 +103,7 @@ nsorros &mdash; Head of Data / AI &middot; CTO
 &gt; currently
 building a vertical AI company that knows its domain
 better than the customers it serves.</pre>
+    </div>
   </section>
 
   <!-- ABOUT -->

--- a/style.css
+++ b/style.css
@@ -237,20 +237,11 @@
   }
   .portrait-caption .muted { color: var(--line); }
 
-  .hero-code {
+  .hero-code-wrap {
     margin-top: 64px;
-    padding: 24px 28px;
-    background: var(--paper);
-    border: 1px solid var(--line);
-    font-size: 12px;
-    line-height: 1.7;
-    color: var(--ink-2);
-    overflow-x: auto;
-    white-space: pre;
     position: relative;
-    font-family: inherit;
   }
-  .hero-code::before {
+  .hero-code-wrap::before {
     content: "─── shell ───";
     position: absolute; top: -1px; left: 16px;
     transform: translateY(-50%);
@@ -260,6 +251,19 @@
     letter-spacing: 0.1em;
     color: var(--muted);
     text-transform: uppercase;
+    z-index: 1;
+  }
+  .hero-code {
+    margin: 0;
+    padding: 24px 28px;
+    background: var(--paper);
+    border: 1px solid var(--line);
+    font-size: 12px;
+    line-height: 1.7;
+    color: var(--ink-2);
+    overflow-x: auto;
+    white-space: pre;
+    font-family: inherit;
   }
 
   /* ABOUT ------------------------------------------------------- */


### PR DESCRIPTION
## Summary

The "─── shell ───" label that straddles the top border of the hero code box was being clipped, leaving only its lower half visible.

**Cause:** `.hero-code` set `overflow-x: auto`. Per the CSS spec, when one overflow axis is set to a non-`visible` value, the other is forced to `auto` too — so `overflow-y` silently became `auto` and clipped the absolutely-positioned `::before` label that pokes above the top border.

**Fix:** Wrap the `<pre>` in a `.hero-code-wrap` container. The wrapper holds the `::before` label (with `overflow: visible`, the default), and the inner `<pre>` keeps `overflow-x: auto` for long lines.

## Test plan

- [ ] Open `index.html` in a browser and confirm the "SHELL" label is fully visible above the top border of the shell box.
- [ ] Resize the viewport so the `[Python, PyTorch, ...]` line overflows and confirm horizontal scrolling still works inside the box.
- [ ] Toggle the theme (light/dark) and confirm the label background still matches the page background.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DczStK6dr2xxExufsT9nqD)_