### PR TITLE
Fix short kind tag and strip authoring metadata from shorts

### DIFF
--- a/writing/agentic-rag-is-the-new-oil/index.html
+++ b/writing/agentic-rag-is-the-new-oil/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.09</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Agentic RAG is the new oil, don&#x27;t miss out!</h1>
     </header>

--- a/writing/agenticai-is-everywhere-but-what-is-an-agent/index.html
+++ b/writing/agenticai-is-everywhere-but-what-is-an-agent/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.08</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">AgenticAI is everywhere — but what is an agent?</h1>
     </header>

--- a/writing/are-we-beginning-to-use-ai-too-much/index.html
+++ b/writing/are-we-beginning-to-use-ai-too-much/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.11</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Are we beginning to use AI too much?</h1>
     </header>

--- a/writing/back-to-trillion-param-models/index.html
+++ b/writing/back-to-trillion-param-models/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.12</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Back to trillion param models</h1>
     </header>

--- a/writing/gemini-35-flash-secret/index.html
+++ b/writing/gemini-35-flash-secret/index.html
@@ -48,11 +48,6 @@
     </header>
 
     <div class="prose">
-<p><strong>Channel:</strong> LinkedIn
-<strong>Status:</strong> posted 2026-05-20
-<strong>Image:</strong> image.png (1200×630, on-brand: off-white #fafaf9 + dot pattern, JetBrains Mono, two side-by-side bar charts showing per-token vs per-task cost — bars flip between the two views)</p>
-<hr />
-<h2>Post body (as posted)</h2>
 <p>Gemini 3.5 Flash's secret 🤫</p>
 <p>Google just released Gemini 3.5 Flash ⚡ and on the spec sheet it looks like a great model:</p>
 <p>🧠 Intelligence Index: 55 (top 7 of 147 on Artificial Analysis)
@@ -64,17 +59,6 @@
 📊 Gemini 3.1 Pro Preview: $892 to complete the same suite</p>
 <p>This paints a different picture. 57 intelligence at $892 vs 55 intelligence at $1,552. The cheaper-per-token model is more expensive because it spends 2.3× more tokens to answer the same questions. Per token Flash is 25% cheaper than Pro. Per task it is 74% more expensive 😱</p>
 <p>Maybe the right way to think about Flash going forward is the speed tier, not the cheap tier. At 278 tok/s it is the fastest model on the intelligence-vs-speed frontier, and that is a real value proposition for latency-sensitive workloads..</p>
-<hr />
-<h2>Source notes</h2>
-<ul>
-<li>Per-token blended pricing (7:2:1 cache/input/output): Artificial Analysis, model pages for <a href="https://artificialanalysis.ai/models/gemini-3-5-flash">Gemini 3.5 Flash</a> and <a href="https://artificialanalysis.ai/models/gemini-3-1-pro-preview">Gemini 3.1 Pro Preview</a>.</li>
-<li>Per-task "cost to evaluate on Intelligence Index": Artificial Analysis, quoted in <a href="https://simonwillison.net/2026/May/19/gemini-35-flash/">Simon Willison's writeup</a>, 19 May 2026.</li>
-<li>Verbosity multiplier (2.3×) derived: $1,552 / $1.31 ≈ 1,185M tokens vs $892 / $1.74 ≈ 513M tokens.</li>
-<li>Related news ledger items:</li>
-<li><code>news/2026-05-19-gemini-35-flash-tier-shift.md</code></li>
-<li><code>news/2026-05-19-google-antigravity-managed-agents.md</code></li>
-<li><code>news/2026-04-30-pragmatic-engineer-token-spend-breaks-budgets.md</code></li>
-</ul>
     </div>
 
     <footer class="article-foot">

--- a/writing/gpt5-is-amazing-or-is-it/index.html
+++ b/writing/gpt5-is-amazing-or-is-it/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.10</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">GPT5 is amazing, or is it?</h1>
     </header>

--- a/writing/harness-is-new-prompt-eng/index.html
+++ b/writing/harness-is-new-prompt-eng/index.html
@@ -48,11 +48,6 @@
     </header>
 
     <div class="prose">
-<p><strong>Channel:</strong> LinkedIn
-<strong>Status:</strong> posted 2026-05-14
-<strong>Image:</strong> image.png (1200×630, on-brand: dot pattern, JetBrains Mono, terminal-prompt title, left-rule accents)</p>
-<hr />
-<h2>Post body (as posted)</h2>
 <p>Will harness engineering have the same fate as prompt engineering?</p>
 <p>Remember how prompt engineering was the talk of town a few years ago? As it turns out, models automated that role before it even took off. Today is all about harness engineering, is that here to stay or will disappear into thin air in a few model iterations?</p>
 <p>Lets decompose the harness and opine on what stays versus what is ephemeral</p>
@@ -62,10 +57,6 @@
 <p>🤖 Sub-agents (when the AI delegates to copies of itself) - spawns child agents in isolated context, hands back results to the parent. Not sure if models are explicitly trained to use agents or are treated as another tool but I suspect that one way or another this will be absorbed by the ability of the model to break down problems and use proper isolation.</p>
 <p>🪝 Hooks, modes and permissions (the real harness) - runs pre, post finish hooks, planning vs doing and which apps, folders AI has access to. The genuine harness is about the restrictions you put into the model and how you use it.</p>
 <p>The agent loop that started thin, grew with harness engineering, will collapse back to thin. while not done: model(tools, memory). The harness that remains is all about restrictions and less so about turbocharging the model. This is not different from an actual harness…</p>
-<hr />
-<h2>Source notes</h2>
-<p>Working notes + research synthesis: see <code>notes.md</code> in this directory.
-Related: <code>content/essays/0000-harness-engineering/research.md</code> (the AHE / Meta-Harness / ACE deep dive that grounds this take).</p>
     </div>
 
     <footer class="article-foot">

--- a/writing/have-you-read-the-ai-2027-analysis/index.html
+++ b/writing/have-you-read-the-ai-2027-analysis/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.02</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Have you read the AI 2027 analysis?</h1>
     </header>

--- a/writing/here-is-how-r1-is-trained/index.html
+++ b/writing/here-is-how-r1-is-trained/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.04</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Here is how R1 is trained</h1>
     </header>

--- a/writing/here-is-how-we-use-ai-at-mantis/index.html
+++ b/writing/here-is-how-we-use-ai-at-mantis/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.01</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Here is how we use AI at Mantis</h1>
     </header>

--- a/writing/here-is-the-issue-with-ai-doing-actual-work/index.html
+++ b/writing/here-is-the-issue-with-ai-doing-actual-work/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.12</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Here is the issue with AI doing actual work</h1>
     </header>

--- a/writing/is-finetuning-era-over/index.html
+++ b/writing/is-finetuning-era-over/index.html
@@ -48,11 +48,6 @@
     </header>
 
     <div class="prose">
-<p><strong>Channel:</strong> LinkedIn
-<strong>Status:</strong> posted 2026-05-19
-<strong>Image:</strong> image.png (1200×630, on-brand: off-white #fafaf9 + dot pattern, ink-black markers, JetBrains Mono, blinking-cursor mark from the favicon, 4-marker timeline <code>scratch → pretrain + finetune → prompt first → ?</code>)</p>
-<hr />
-<h2>Post body (as posted)</h2>
 <p>Is the finetuning era over?</p>
 <p>If so, it's a big shift, though one so gradual it won't shock anyone.</p>
 <p>Here is the transition:
@@ -61,9 +56,6 @@
  • LLMs landed. Suddenly models worked out of the box. Prompting became the first adjustment and finetuning the last, one most teams never did.</p>
 <p>Now we're past that point too. The right instructions, well-scoped skills, and tools delivers most, if not all of the value fine tuning did. That does not mean fine tuning is not needed, smaller models still have benefits. Some verticals still need it. But as frontier models get cheaper and faster, that need is evaporating quickly.</p>
 <p>This begs the question: are we heading toward general models for everything, steered rather than tuned? Where does finetuning still earn its place?</p>
-<hr />
-<h2>Source notes</h2>
-<p>Based on the OpenAI deprecates-finetuning ledger item: <a href="../../../news/2026-05-13-openai-deprecates-finetuning.md">news/2026-05-13-openai-deprecates-finetuning.md</a>.</p>
     </div>
 
     <footer class="article-foot">

--- a/writing/lets-talk-about-clawdbot/index.html
+++ b/writing/lets-talk-about-clawdbot/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.04</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Let&#x27;s talk about clawdbot</h1>
     </header>

--- a/writing/my-take-on-gemini-3/index.html
+++ b/writing/my-take-on-gemini-3/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.03</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">My take on Gemini 3</h1>
     </header>

--- a/writing/my-take-on-reflection-and-o1/index.html
+++ b/writing/my-take-on-reflection-and-o1/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2024.12</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">My take on Reflection and o1</h1>
     </header>

--- a/writing/open-weights-update/index.html
+++ b/writing/open-weights-update/index.html
@@ -48,15 +48,10 @@
     </header>
 
     <div class="prose">
-<p><strong>Target channel:</strong> LinkedIn
-<strong>Status:</strong> ready to schedule (post + image done)</p>
-<hr />
-<h2>Post body</h2>
 <p>Open weights update — not groundbreaking, but worth noting where we are.</p>
 <p>Two tiers exist today: <strong>frontier</strong> (Opus 4.7, GPT-5.5) and <strong>previous generation</strong> (Opus 4.6, Sonnet 4.6, GPT-5.4). Open weights — Kimi K2.6, DeepSeek V4 Pro, MiMo V2.5 Pro — now sit at the previous-generation level, at 3-5× lower cost.</p>
 <p>The gap used to be much wider. GPT-3.5 → GPT-4 was ~18 months. Open weights spent that whole window playing catch-up to the previous generation. Today the frontier moves every ~2 months — Opus 4.7 shipped 10 weeks after 4.6, GPT-5.5 seven weeks after 5.4 — and open weights are right behind it.</p>
 <p>Does the gap still matter? Yes, for some work. For coding and agentic tasks, where marginal frontier capability is load-bearing, no one ships on the previous generation. For extraction, summarization, and most non-agentic LLM work, previous-gen (open or cheaper closed) delivers fine — and the cost savings are real.</p>
-<p>[image: open-weights-vs-frontier-may-2026.png]</p>
 <hr />
 <h2>Benchmark table — final numbers</h2>
 <table>

--- a/writing/prototyping-with-large-language-models/index.html
+++ b/writing/prototyping-with-large-language-models/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2023.06</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Prototyping with Large Language Models</h1>
     </header>

--- a/writing/software-engineers-are-obsolete-or-are-they/index.html
+++ b/writing/software-engineers-are-obsolete-or-are-they/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.02</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Software engineers are obsolete, or are they?</h1>
     </header>

--- a/writing/the-ai-disruption-matrix/index.html
+++ b/writing/the-ai-disruption-matrix/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.04</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The AI disruption matrix</h1>
     </header>

--- a/writing/the-end-of-repetitive-tasks/index.html
+++ b/writing/the-end-of-repetitive-tasks/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.05</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The end of repetitive tasks</h1>
     </header>

--- a/writing/the-future-of-work/index.html
+++ b/writing/the-future-of-work/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.03</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The future of work</h1>
     </header>

--- a/writing/the-missing-ingredient-for-agi/index.html
+++ b/writing/the-missing-ingredient-for-agi/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.03</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The missing ingredient for AGI</h1>
     </header>

--- a/writing/the-way-we-work-is-about-to-change/index.html
+++ b/writing/the-way-we-work-is-about-to-change/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.01</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The way we work is about to change</h1>
     </header>

--- a/writing/the-year-of-agents/index.html
+++ b/writing/the-year-of-agents/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.03</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The year of agents</h1>
     </header>

--- a/writing/the-year-that-google-strikes-back/index.html
+++ b/writing/the-year-that-google-strikes-back/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.03</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">The year that Google strikes back</h1>
     </header>

--- a/writing/upskilling-software-eng-team/index.html
+++ b/writing/upskilling-software-eng-team/index.html
@@ -48,11 +48,6 @@
     </header>
 
     <div class="prose">
-<p><strong>AI Solutions &amp; Case Studies</strong>
-• <strong>Post</strong>: How we helpt train a team and make the organization more AI savvy, which helped them  to produce,y,z,
-• <strong>Goal</strong>: Emphasize the service aspect of Mantis and our experience with training/workshops
-• <strong>CTA:</strong> Schedule a free innovation call to discover how we can help you optimize your team and business processes with AI: (Link to innovation call)
-• <strong>Visual: Template:</strong><a href="https://www.canva.com/design/DAGpfXPtTls/YFqLvm_wO5qW0Q95TI0yYw/edit?utm_content=DAGpfXPtTls&amp;utm_campaign=designshare&amp;utm_medium=link2&amp;utm_source=sharebutton">https://www.canva.com/design/DAGpfXPtTls/YFqLvm_wO5qW0Q95TI0yYw/edit?utm_content=DAGpfXPtTls&amp;utm_campaign=designshare&amp;utm_medium=link2&amp;utm_source=sharebutton</a> <strong>(there are two options - the black template or the green one)</strong></p>
 <p>🚀 Transforming Software Teams with AI Excellence: A Success Story</p>
 <p>We recently had the privilege of working with a US-based software company facing a common challenge: the need to upskill their data engineering team in AI development. Here's how we turned this challenge into a success story.</p>
 <p>🎯 The Challenge:

--- a/writing/what-happened-with-gpt4-5/index.html
+++ b/writing/what-happened-with-gpt4-5/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.05</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">What happened with GPT4.5?</h1>
     </header>

--- a/writing/what-is-going-on-with-deepseek/index.html
+++ b/writing/what-is-going-on-with-deepseek/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.04</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">What is going on with DeepSeek?</h1>
     </header>

--- a/writing/what-makes-companies-fail/index.html
+++ b/writing/what-makes-companies-fail/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2026.02</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">What makes companies fail</h1>
     </header>

--- a/writing/what-should-you-expect-from-ai-near-term/index.html
+++ b/writing/what-should-you-expect-from-ai-near-term/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.05</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">What should you expect from AI in the near term?</h1>
     </header>

--- a/writing/whats-going-on-with-mcp/index.html
+++ b/writing/whats-going-on-with-mcp/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.07</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">What&#x27;s going on with MCP?</h1>
     </header>

--- a/writing/will-ai-make-your-role-obsolete/index.html
+++ b/writing/will-ai-make-your-role-obsolete/index.html
@@ -42,7 +42,7 @@
       <div class="article-meta">
         <span class="m-date">2025.06</span>
         <span class="sep">·</span>
-        <span class="m-kind">essay</span>
+        <span class="m-kind">short</span>
       </div>
       <h1 class="article-title">Will AI make your role obsolete?</h1>
     </header>


### PR DESCRIPTION
## Summary

Two cleanups across the `writing/` shorts:

- **Tag mismatch**: 27 shorts had `<span class="m-kind">essay</span>` on their individual pages even though `writing/index.html` classifies them as `data-kind="short"` (and they show up under the short filter). Updated each page's `m-kind` to `short` so the per-article meta matches the archive.
- **Leftover authoring metadata**: 5 shorts had pre-publish notes that leaked into the rendered page. Removed:
  - Top-of-post `Channel: / Status: / Image:` (or `Target channel: / Status:`) blocks plus their trailing `<hr />`
  - Redundant `Post body` / `Post body (as posted)` `<h2>` headings inside the article
  - `Source notes` sections that link to the local news-ledger / `notes.md` / `content/essays/...` paths
  - The `[image: ...png]` placeholder line in `open-weights-update`
  - The `AI Solutions & Case Studies / Post / Goal / CTA / Visual: Template` planning block at the top of `upskilling-software-eng-team`

Affected for metadata cleanup: `gemini-35-flash-secret`, `is-finetuning-era-over`, `harness-is-new-prompt-eng`, `open-weights-update`, `upskilling-software-eng-team`. The external `Sources` and `Benchmark table` sections in `open-weights-update` were kept as genuine content.

## Test plan

- [ ] Open a few of the renamed shorts (e.g. `/writing/the-end-of-repetitive-tasks/`) and confirm the meta now reads `short` instead of `essay`
- [ ] Open the 5 cleaned shorts and confirm no Channel/Status/Image preamble, no "Post body" heading, no news-ledger Source notes
- [ ] Confirm the "short" filter on `/writing/` still lists the same entries


---
_Generated by [Claude Code](https://claude.ai/code/session_01XKd4BXHBi1Z2uYb5rD1PXQ)_