### PR TITLE
Publish two quick-take shorts (open-vs-closed, measuring intelligence)

### DIFF
--- a/writing/index.html
+++ b/writing/index.html
@@ -124,6 +124,20 @@
 
       <h2 class="archive-year">2026</h2>
       <ul class="writing-list">
+        <li class="writing-row" data-kind="short"><a href="./we-might-be-measuring-intelligence-wrong/">
+          <span class="writing-date">2026.07</span>
+          <span class="writing-title">We might be measuring intelligence wrong</span>
+          <span class="writing-kind">short</span>
+          <span class="writing-read"></span>
+          <span class="writing-arrow">&rarr;</span>
+        </a></li>
+        <li class="writing-row" data-kind="short"><a href="./two-monarchies-open-vs-closed/">
+          <span class="writing-date">2026.07</span>
+          <span class="writing-title">Two monarchies, open vs closed</span>
+          <span class="writing-kind">short</span>
+          <span class="writing-read"></span>
+          <span class="writing-arrow">&rarr;</span>
+        </a></li>
         <li class="writing-row" data-kind="short"><a href="./anthropic-takes-the-lead-with-fable/">
           <span class="writing-date">2026.06</span>
           <span class="writing-title">Anthropic takes the lead with Fable</span>

--- a/writing/two-monarchies-open-vs-closed/index.html
+++ b/writing/two-monarchies-open-vs-closed/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>Two monarchies, open vs closed — Nick Sorros</title>
+<meta name="description" content="Two monarchies, open vs closed — by Nick Sorros." />
+<link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+
+<header class="topbar">
+  <div class="topbar-inner">
+    <a href="../../" class="brand" style="text-decoration:none;">
+      <span class="brand-mark"></span>
+      <span class="brand-text">nsorros</span>
+      <span class="brand-domain">.com</span>
+    </a>
+    <nav class="nav">
+      <a href="../../#about">about</a>
+      <a href="../../#work">work</a>
+      <a href="../../#writing">writing</a>
+      <a href="../../#contact">contact</a>
+    </nav>
+    <div class="topbar-meta">
+      <span class="status-dot"></span>
+      <span>online</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">dark</button>
+    </div>
+  </div>
+</header>
+
+<main class="page article">
+  <a class="back-link" href="../../#writing">← back to writing</a>
+
+  <article>
+    <header class="article-head">
+      <div class="article-meta">
+        <span class="m-date">2026.07</span>
+        <span class="sep">·</span>
+        <span class="m-kind">short</span>
+      </div>
+      <h1 class="article-title">Two monarchies, open vs closed</h1>
+    </header>
+
+    <div class="prose">
+<p>Closed AI is a US monopoly (Anthropic); open AI is effectively a Chinese one (DeepSeek, Kimi, GLM, MiMo), with the open crown rotating every few weeks.</p>
+<p>GLM-5.2 now leads the open pack, ~5 index points behind the frontier — and for most real coding work, one generation behind already buys most of the value at a fraction of the cost, on weights you host.</p>
+    </div>
+
+    <footer class="article-foot">
+      <a class="back-link" href="../../#writing">← back to writing</a>
+    </footer>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-grid">
+    <div class="foot-cell">© 2014—2026 · Nick Sorros</div>
+    <div class="foot-cell center">
+      <span class="status-dot"></span> systems nominal
+    </div>
+    <div class="foot-cell right">
+      built using <span class="mono-tight">AI</span> · deployed <span class="mono-tight" id="deploy-date">$(date)</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function() {
+    var root = document.documentElement;
+    var btn = document.getElementById('theme-toggle');
+    var stored = localStorage.getItem('theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var initial = stored || (prefersDark ? 'dark' : 'light');
+    apply(initial);
+    if (btn) btn.addEventListener('click', function() {
+      apply(root.dataset.theme === 'dark' ? 'light' : 'dark');
+    });
+    function apply(t) {
+      root.dataset.theme = t;
+      if (btn) btn.textContent = t === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', t);
+    }
+  })();
+  (function() {
+    var el = document.getElementById('deploy-date');
+    if (!el) return;
+    var d = new Date();
+    var pad = function(n) { return n < 10 ? '0' + n : n; };
+    el.textContent = d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate());
+  })();
+</script>
+</body>
+</html>

--- a/writing/we-might-be-measuring-intelligence-wrong/index.html
+++ b/writing/we-might-be-measuring-intelligence-wrong/index.html
@@ -1,0 +1,99 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width,initial-scale=1" />
+<title>We might be measuring intelligence wrong — Nick Sorros</title>
+<meta name="description" content="We might be measuring intelligence wrong — by Nick Sorros." />
+<link rel="icon" type="image/svg+xml" href="../../assets/favicon.svg" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&display=swap" rel="stylesheet" />
+<link rel="stylesheet" href="../../style.css" />
+</head>
+<body>
+
+<header class="topbar">
+  <div class="topbar-inner">
+    <a href="../../" class="brand" style="text-decoration:none;">
+      <span class="brand-mark"></span>
+      <span class="brand-text">nsorros</span>
+      <span class="brand-domain">.com</span>
+    </a>
+    <nav class="nav">
+      <a href="../../#about">about</a>
+      <a href="../../#work">work</a>
+      <a href="../../#writing">writing</a>
+      <a href="../../#contact">contact</a>
+    </nav>
+    <div class="topbar-meta">
+      <span class="status-dot"></span>
+      <span>online</span>
+      <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">dark</button>
+    </div>
+  </div>
+</header>
+
+<main class="page article">
+  <a class="back-link" href="../../#writing">← back to writing</a>
+
+  <article>
+    <header class="article-head">
+      <div class="article-meta">
+        <span class="m-date">2026.07</span>
+        <span class="sep">·</span>
+        <span class="m-kind">short</span>
+      </div>
+      <h1 class="article-title">We might be measuring intelligence wrong</h1>
+    </header>
+
+    <div class="prose">
+<p>Benchmarks reward pass@k, right at least once in k tries. But agents act once, so what matters is pass&and;k, right every time.</p>
+<p>Capability has raced ahead; reliability is climbing behind it — which is why the impressive monthly numbers don't always translate to impressive agentic performance.</p>
+    </div>
+
+    <footer class="article-foot">
+      <a class="back-link" href="../../#writing">← back to writing</a>
+    </footer>
+  </article>
+</main>
+
+<footer class="footer">
+  <div class="footer-grid">
+    <div class="foot-cell">© 2014—2026 · Nick Sorros</div>
+    <div class="foot-cell center">
+      <span class="status-dot"></span> systems nominal
+    </div>
+    <div class="foot-cell right">
+      built using <span class="mono-tight">AI</span> · deployed <span class="mono-tight" id="deploy-date">$(date)</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+  (function() {
+    var root = document.documentElement;
+    var btn = document.getElementById('theme-toggle');
+    var stored = localStorage.getItem('theme');
+    var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+    var initial = stored || (prefersDark ? 'dark' : 'light');
+    apply(initial);
+    if (btn) btn.addEventListener('click', function() {
+      apply(root.dataset.theme === 'dark' ? 'light' : 'dark');
+    });
+    function apply(t) {
+      root.dataset.theme = t;
+      if (btn) btn.textContent = t === 'dark' ? 'light' : 'dark';
+      localStorage.setItem('theme', t);
+    }
+  })();
+  (function() {
+    var el = document.getElementById('deploy-date');
+    if (!el) return;
+    var d = new Date();
+    var pad = function(n) { return n < 10 ? '0' + n : n; };
+    el.textContent = d.getUTCFullYear() + '-' + pad(d.getUTCMonth() + 1) + '-' + pad(d.getUTCDate());
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Publishes two of the "quick takes" as linkable `/writing` shorts so they can be referenced with their own URLs.

**New shorts (2026.07):**
- `Two monarchies, open vs closed` → `/writing/two-monarchies-open-vs-closed/`
- `We might be measuring intelligence wrong` → `/writing/we-might-be-measuring-intelligence-wrong/`

Both use the existing short template (same as the Fable short) and are added to the top of the 2026 archive list. Content is verbatim from the source takes.

The third take, "Anthropic takes the lead with Fable", was already published, so it's untouched.

**Merging this to `master` publishes them live via GitHub Pages.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175je5EujByXACv7Kk351Gt