### PR TITLE
Add open_source projects section

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
       <a href="#about">about</a>
       <a href="#work">work</a>
       <a href="#writing">writing</a>
+      <a href="#projects">projects</a>
       <a href="#contact">contact</a>
     </nav>
     <div class="topbar-meta">
@@ -46,7 +47,7 @@
         </div>
         <div class="kv">
           <span class="k">last_modified</span>
-          <span class="v">2026-05-04</span>
+          <span class="v">2026-07-10</span>
         </div>
         <div class="kv">
           <span class="k">status</span>
@@ -269,10 +270,57 @@ it had no business working.</pre>
     </form>
   </section>
 
+  <!-- PROJECTS -->
+  <section class="work" id="projects">
+    <div class="section-marker">
+      <span class="marker-num">[04]</span>
+      <span class="marker-line"></span>
+      <span class="marker-label">// open_source</span>
+    </div>
+    <ul class="work-list">
+      <li class="work-row">
+        <div class="work-year">2026</div>
+        <div class="work-main">
+          <div class="work-head">
+            <a class="work-co" href="https://github.com/nsorros/meeting-recorder" target="_blank" rel="noopener">meeting-recorder</a>
+            <span class="work-role">macOS &middot; open source</span>
+          </div>
+          <p class="work-note">Local-first macOS meeting recorder. Spots a Meet, Zoom or Teams call, asks before recording, captures the audio with ffmpeg, transcribes on-device with Whisper, then optionally has Claude tidy the raw transcript into notes. Nothing leaves the machine unless you ask.</p>
+          <div class="work-tags">
+            <span class="tag">macOS</span>
+            <span class="tag">Whisper</span>
+            <span class="tag">CLI</span>
+          </div>
+        </div>
+        <div class="work-num">01</div>
+      </li>
+
+      <li class="work-row">
+        <div class="work-year">2026</div>
+        <div class="work-main">
+          <div class="work-head">
+            <a class="work-co" href="https://github.com/nsorros/menubar" target="_blank" rel="noopener">menubar</a>
+            <span class="work-role">macOS &middot; open source</span>
+          </div>
+          <p class="work-note">Two macOS menu-bar widgets, built as xbar plugins &mdash; live Claude usage (the 5-hour and weekly windows, straight from the OAuth usage API) and internet speed from a background speedtest probe. Glanceable, with nothing to open.</p>
+          <div class="work-tags">
+            <span class="tag">macOS</span>
+            <span class="tag">Python</span>
+            <span class="tag">xbar</span>
+          </div>
+        </div>
+        <div class="work-num">02</div>
+      </li>
+    </ul>
+    <div class="writing-more">
+      <a href="https://github.com/nsorros" target="_blank" rel="noopener">&rarr; more on github</a>
+    </div>
+  </section>
+
   <!-- TRUST -->
   <section class="trust">
     <div class="section-marker">
-      <span class="marker-num">[04]</span>
+      <span class="marker-num">[05]</span>
       <span class="marker-line"></span>
       <span class="marker-label">// trusted_by</span>
     </div>
@@ -293,7 +341,7 @@ it had no business working.</pre>
   <!-- TESTIMONIALS -->
   <section class="testimonials">
     <div class="section-marker">
-      <span class="marker-num">[05]</span>
+      <span class="marker-num">[06]</span>
       <span class="marker-line"></span>
       <span class="marker-label">// testimonials</span>
     </div>
@@ -325,7 +373,7 @@ it had no business working.</pre>
   <!-- CONTACT -->
   <section class="contact" id="contact">
     <div class="section-marker">
-      <span class="marker-num">[06]</span>
+      <span class="marker-num">[07]</span>
       <span class="marker-line"></span>
       <span class="marker-label">// contact</span>
     </div>


### PR DESCRIPTION
Adds a `[04] // open_source` section to the homepage, between `// writing` and `// trusted_by`, listing the two public repos:

- **meeting-recorder** — local-first macOS meeting recorder (Whisper + optional Claude cleanup)
- **menubar** — macOS menu-bar widgets (Claude usage + net speed) as xbar plugins

Details:
- Reuses existing `work-row` / `work-co` / `tag` classes — **no CSS changes**, so it matches the rest of the page exactly.
- Adds a `projects` nav link; renumbers trailing section markers to `[05]`–`[07]`.
- Bumps hero `last_modified` to 2026-07-10.

Verified with a headless-Chrome render — section renders identically-styled to the work list above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)