### PR TITLE
Replace /work-with-me examples with verified Mantis case studies

### DIFF
--- a/work-with-me/index.html
+++ b/work-with-me/index.html
@@ -123,7 +123,7 @@
       <div class="offer-body">
         <div class="card">
           <span class="card-label">// where this shows up</span>
-          <p><strong>Datamaran.</strong> The AI-driven ESG &amp; non-financial-risk intelligence platform &mdash; exactly this kind of engagement: a senior read on where AI and LLMs could most strengthen their product and analytics, and a clear-eyed plan for getting there before committing the build.</p>
+          <p><strong>The Heritage Fund.</strong> For the UK&rsquo;s largest heritage funder, this looked like leading a workshop on AI and business transformation for their leadership, then scoping AI tagging and classification across their grants &mdash; assessing where AI genuinely helps, aligning it to the mission, and setting the plan before anyone builds.</p>
         </div>
         <div class="card quote-card">
           <p class="t-quote">&ldquo;Calm, collected, and always on top of the ML/AI industry &mdash; steering the ship with precision without falling for hype. He aligns technical decisions with clients&rsquo; business objectives, and as a leader provides valuable guidance and takes feedback into account.&rdquo;</p>
@@ -162,7 +162,7 @@
       <div class="offer-body">
         <div class="card">
           <span class="card-label">// where this shows up</span>
-          <p><strong>Oxford Medical Simulation &amp; Mantis.</strong> Embedded with OMS to build and ship a custom transformer and multi-head classifier for their VR medical training &mdash; scaling to thousands of labels, into production. Across Mantis, 30+ engagements taking ML from boardroom slide to shipped system, with the team to run it.</p>
+          <p><strong>Datamaran, Addgene &amp; Oxford Medical Simulation.</strong> Embedded, hands-on delivery. Built and deployed a retrieval-augmented (RAG) system &mdash; with its own evaluation harness &mdash; into Datamaran&rsquo;s ESG-intelligence platform. Currently own the AI recommendation-engine build and its expert evaluation for Addgene&rsquo;s research catalogue. Ran an embedded ML team inside Oxford Medical Simulation&rsquo;s own stack for their VR clinical training. Owning the strategy, the build, and the evals &mdash; not just advising.</p>
         </div>
         <div class="card quote-card">
           <p class="t-quote">&ldquo;Mantis have been a key component of our growth within the LLM domain. Their expertise, pragmatism and collaborative approach has made them a trusted partner to accelerate our ML advancements.&rdquo;</p>
@@ -198,12 +198,13 @@
       <div class="offer-body">
         <div class="card">
           <span class="card-label">// where this shows up</span>
-          <p><strong>A decade of exactly these calls.</strong> Language detection at scale, recommender systems, and factuality checks on entrepreneur statements at Seedrs, FactSet and Conversocial &mdash; the &ldquo;build it, buy it, or don&rsquo;t do it&rdquo; judgment that only comes from having shipped the real thing, repeatedly.</p>
+          <p><strong>GSMA &amp; FIND.</strong> High-leverage, bounded work. For GSMA, designed the Q&amp;A dataset and open-sourced the dataset-creation tooling behind their Open Telco AI models, with a contribution to the accompanying NeurIPS paper. For FIND, built a multi-LLM extraction pipeline &mdash; benchmarking GPT-4, Claude and Gemini against a human-labelled ground truth &mdash; to de-risk an LLM approach before they committed to it. The judgment to scope the right thing, and prove it works.</p>
         </div>
         <div class="card quote-card">
-          <p class="t-quote">Trusted by teams at <strong>Wellcome, GSMA, Oxford Medical Simulation, Rockefeller, FIND, Addgene, Seedrs</strong> and <strong>FactSet</strong> &mdash; from seed-stage startups to FTSE-listed companies, governments, foundations and research institutions.</p>
+          <p class="t-quote">&ldquo;We trust the quality of Mantis&rsquo;s work and the diligence they take in getting to solutions. They work collaboratively, support our internal data scientists, and feel like part of our team.&rdquo;</p>
           <div class="t-attr">
-            <span class="t-role">// trusted_by</span>
+            <span class="t-name">Alasdair Fraser</span>
+            <span class="t-role">Head of Data &amp; Digital, The Wellcome Trust</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The `/work-with-me` examples were inferred and partly mis-tiered. Replaced with **verified case studies** mined from the Mantis inbox — all current (2024–26) and correctly tiered.

| Tier | Was | Now (verified) |
|---|---|---|
| AI Audit & Roadmap | Datamaran (as "scoping") | **The Heritage Fund** — AI & business-transformation workshop + tagging scoping |
| Fractional Head of AI | OMS custom-transformer | **Datamaran** (RAG build + eval harness), **Addgene** (live AI recommendation POC), **OMS** (embedded ML team) |
| AI Advisor / Board | Seedrs/FactSet heritage | **GSMA** (Open Telco dataset + open-source + NeurIPS) & **FIND** (multi-LLM extraction PoC) |

Key fix: **Datamaran was mis-filed as an "audit"** — the real engagement was a **RAG system build + evaluation**, so it moves to the delivery/Fractional tier. Advisor testimonial upgraded from a generic trusted-by line to **Alasdair Fraser (Head of Data, Wellcome Trust)**.

No numbers/quotes are claimed that aren't supported by the source emails.

🤖 Generated with [Claude Code](https://claude.com/claude-code)